### PR TITLE
バックエンド: SocketIOのCORS設定を特定のオリジンのみ許可するように修正。フロントエンド: WebSocketサーバーのURL…

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -15,9 +15,23 @@ import copy
 
 # --- Flask アプリケーション設定 ---
 app = Flask(__name__)
-# SocketIO の設定を追加 (CORS を許可)
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode='eventlet')
-CORS(app) # コメント解除して Flask アプリ全体で CORS を有効化
+
+# 許可するオリジンをリストで指定
+allowed_origins = [
+    # Amplify のドメインパターン
+    "https://*.amplifyapp.com",
+    # ローカル開発用
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    # 将来的に設定する可能性のあるカスタムドメインも念のため追加しておく場合
+    # "https://yamob.net",
+    # "https://www.yamob.net",
+]
+# print(f"Allowed Origins: {allowed_origins}") # デバッグ用
+
+# SocketIO の設定を修正 (特定のオリジンのみ許可)
+socketio = SocketIO(app, cors_allowed_origins=allowed_origins, async_mode='eventlet')
+# CORS(app) # Flask-SocketIO が CORS ヘッダーを処理するのでコメントアウトまたは削除推奨
 
 # --- シミュレーターとスレッド管理 ---
 loader = DataLoader()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,9 +61,9 @@ interface SimulationState {
 }
 // --- 型定義ここまで ---
 
-// WebSocketサーバーのURL (環境変数から取得するか、デフォルト値を設定)
-// Linter Error: Cannot find name 'process' -> Use import.meta.env for Vite
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:5001';
+// WebSocketサーバーのURL (Amplifyのプロキシ経由で同じオリジンに接続)
+// const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:5001'; // 修正前
+const SOCKET_URL = ''; // 修正後: 空文字列にして相対パスで接続
 
 // Linter Error 修正: 重複定義を削除
 // type SimulationState = any;

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,8 +5,30 @@ resource "aws_amplify_app" "yamob_app" {
   repository   = "https://github.com/tyamori/yamob"
   access_token = var.github_token
 
-  environment_variables = {
-    VITE_SOCKET_URL = "http://${aws_lb.yamob_backend_alb.dns_name}"
+  # 削除: 環境変数はプロキシを使うため不要
+  # environment_variables = {
+  #   VITE_SOCKET_URL = "http://${aws_lb.yamob_backend_alb.dns_name}"
+  # }
+
+  # 追加: カスタムルール (プロキシとSPAフォールバック)
+  # ルールは順序が重要。具体的なパスが先、汎用的なフォールバックが後。
+  custom_rule {
+    source = "/api/<*>"
+    target = "https://api.yamob.net/api/<*>" # 取得したドメイン名に変更
+    status = "200" # 200番リライト (プロキシ)
+  }
+
+  custom_rule {
+    source = "/socket.io/<*>"
+    target = "https://api.yamob.net/socket.io/<*>" # 取得したドメイン名に変更
+    status = "200" # 200番リライト (プロキシ)
+  }
+
+  # SPA フォールバックルール (これが最後)
+  custom_rule {
+    source = "/<*>" # 上記ルールに一致しない他のすべてのパス
+    target = "/index.html" # index.htmlを返す
+    status = "404-200"     # 404 を 200 に書き換えて index.html を返す
   }
 
   build_spec = <<-EOT


### PR DESCRIPTION
…を相対パスで接続するために空文字列に変更。Terraform: ACM証明書とRoute 53の設定を追加し、ALBリスナーのHTTPS設定を更新。